### PR TITLE
Add pipe char to keymaps

### DIFF
--- a/k2.md
+++ b/k2.md
@@ -101,10 +101,10 @@ When the keymap is changed to en-GB many characters useful for Linux administrat
 The following is a list of the characters I have been able to locate on the changed keymap. The `\ |` describes the  key above enter on the Keychron K2. 
 ```
 # = "\ |" 
+| = AltGr + ` 
 \ = AltGr + "\ |"  
 ~ = Shift + "\ |"
 ```
-I have not located `|`
 
 ## Firmware
 Keychron are investigating [Linux Vendor Firmware Service](https://fwupd.org/) as a possible solution to delivering firmware on Linux, at present it is only possible to update the firmware via Windows.

--- a/k2.md
+++ b/k2.md
@@ -98,10 +98,13 @@ Reference: [Ask Ubuntu](https://askubuntu.com/questions/158333/how-to-create-a-s
 ### Keymap: en-GB (United Kingdom) 
 When the keymap is changed to en-GB many characters useful for Linux administration and programming are hard to find. 
 
-The following is a list of the characters I have been able to locate on the changed keymap. The `\ |` describes the  key above enter on the Keychron K2. 
+The following is a list of the characters I have been able to locate on the changed keymap.  
+The `\ ~` describes the key above enter on the Keychron K2.  
+The \` ~ describes the key above tab on the Keychron K2.  
+
 ```
-# = "\ |" 
-| = AltGr + ` 
+# = "` |" 
+| = AltGr + "` ~" 
 \ = AltGr + "\ |"  
 ~ = Shift + "\ |"
 ```


### PR DESCRIPTION
Recently received the K3 and was able to
use `|` with

```
AltGr + `
```

Feel free to test with the K2 and merge if
this works so it can help others.

[Preview](https://github.com/Kurgol/keychron/blob/4c30fd1302e5c616304d9e71544a12a30a60aaed/k2.md#keymap-en-gb-united-kingdom)