### PR TITLE
Make function keys work

### DIFF
--- a/k2.md
+++ b/k2.md
@@ -64,7 +64,7 @@ There is a [discussion on Stackexchange](https://unix.stackexchange.com/question
 
 [Claus Zotter](https://www.facebook.com/claus.zotter) noticed the `F1` ⇾ `F12` keys always act as though `function` key is pressed.
 
-Edit (create if it doesn't exist, it doesn't on 16.04) `etc/modprobe.d/hid_apple.conf` and add the line `options hid_apple fnmode=2` followed by:
+Edit (create if it doesn't exist, it doesn't on 16.04) `/etc/modprobe.d/hid_apple.conf` and add the line `options hid_apple fnmode=2` followed by:
 
 ```
 $ sudo update-initramfs -u && reboot


### PR DESCRIPTION
I might be a Linux noob, but I think the added slash in the beginning make it easier for people like me to make the functions keys to work.

Because I couldn't understand why it wouldn't work when I copied:

`etc/modprobe.d/hid_apple.conf`

And ran the following command:

`sudo nano etc/modprobe.d/hid_apple.conf`

-----

Anyways if you want to update the README further, this was the steps I did to make it work:

`sudo nano /etc/modprobe.d/hid_apple.conf`

Copy & paste:
`options hid_apple fnmode=2`

Press `ctrl+o `and then` ctrl+x` to exit.

Then run:
`sudo update-initramfs -u && reboot`